### PR TITLE
Markdown support in Patsr

### DIFF
--- a/markdown/md.js
+++ b/markdown/md.js
@@ -1,0 +1,39 @@
+class MarkdownText {
+    constructor(text) {
+        this.text = text;
+        this.markdown = require('markdown').markdown
+    }
+
+    toParseTree() {
+        this.tree = this.markdown.parse(this.text)
+        return this
+    }
+
+    filterTags(tags) {
+        exciseMarkdownTags(this.tree, tags)
+        console.log("tree: ", this.tree);
+        return this
+    }
+
+    toHtml() {
+        return this.markdown.renderJsonML(this.markdown.toHTMLTree(this.tree))
+    }
+}
+
+
+
+function exciseMarkdownTags(tree, tags) {
+    for (let i = 0; i < tree.length; i++) {
+        if (Array.isArray(tree[i])) {
+            if (tags.includes(tree[i][0])) {
+                tree.splice(i, 1)
+            } else {
+                exciseMarkdownTags(tree[i], tags)
+            }
+        }
+    }
+}
+
+module.exports.parseMarkdown = function(text) {
+    return new MarkdownText(text).toParseTree()
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express": "^4.14.0",
     "express-recaptcha": "^2.1.0",
     "jade": "~1.11.0",
+	"markdown": "~0.5.0",
     "mongoose": "^4.7.5",
     "morgan": "~1.7.0",
     "serve-favicon": "~2.3.0"

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,6 +5,7 @@ var Posts = require('../dbModels/posts.js');
 var bodyParser = require('body-parser');
 var recaptcha = require('express-recaptcha');
 var config = require('config');
+var parseMarkdown = require('../markdown/md.js').parseMarkdown;
 
 // config declarations
 var pubKey = config.get('Backend.ReCAPTCHA.pubKey');
@@ -12,6 +13,7 @@ var privKey = config.get('Backend.ReCAPTCHA.privKey');
 var hostURL = config.get('Backend.Host.url');
 var postPerPage = config.get('Frontend.Posts.perPage');
 var viewsPerPage = config.get('Frontend.Posts.viewsPerPage');
+
 
 // reCAPTCHA initiation
 recaptcha.init(pubKey, privKey);
@@ -209,6 +211,7 @@ router.get('/Search', function(req, res, next) {
     res.render('Search/index');
 });
 
+const stripTag = tag => tag.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 // POST request to /Text or /Image creates new respective post
 router.post('/Text', function(req, res, next) {
     recaptcha.verify(req, function(error) {
@@ -222,27 +225,28 @@ router.post('/Text', function(req, res, next) {
 	    var views = req.body.views;
 	    var references = req.body.references;
 	    var referencesSplit = references.split(', ');
-	    
+
 	    if (tags.indexOf('#') != -1 || tags.indexOf('$') != -1 || tags.indexOf(';') != -1) {
-		res.send(res.render('error/tagParsing'));
+		    res.send(res.render('error/tagParsing'));
 	    }
 	    else {
-		if (title != null) {
-		    title = title.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-		}
-		if (content != null) {
-		    content = content.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-		}
-		for (var i = 0; i < tagsSplit.length; i++) {
-		    if (tagsSplit[i] != null) {
-			tagsSplit[i] = tagsSplit[i].replace(/</g, "&lt;").replace(/>/g, "&gt;");
-		    }
-		}
+    		if (title != null) {
+    		    title = parseMarkdown(title).filterTags(['img']).toHtml();
+    		}
+    		if (content != null) {
+    		    content = parseMarkdown(content).filterTags(['img']).toHtml();
+    		}
 
-		Posts.create({type: type, title: title, content: content, tags: tagsSplit, views: views, references: referencesSplit}, function(err, textPost) {
-		    if (err) return next(err);
-		    res.send(res.render('post/new', {postId: textPost._id, host: hostURL}));
-		});
+            for (var i = 0; i < tagsSplit.length; i++) {
+                if (tagsSplit[i] != null) {
+                    tagsSplit[i] = stripTag(tagsSplit[i])
+                }
+            }
+
+    		Posts.create({type: type, title: title, content: content, tags: tagsSplit, views: views, references: referencesSplit}, function(err, textPost) {
+    		    if (err) return next(err);
+    		    res.send(res.render('post/new', {postId: textPost._id, host: hostURL}));
+    		});
 	    }
 	}
 	else {
@@ -270,16 +274,22 @@ router.post('/Image', function(req, res, next) {
 	    }
 	    else {
 		if (title != null) {
-		    title = title.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+		    title = parseMarkdown(title).filterTags(['img']).toHtml()
 		}
 		if (content != null) {
-		    content = content.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+		    content = stripTag(content)
 		}
-		for (var i = 0; i < tagsSplit.length; i++) {
-		    if (tagsSplit[i] != null) {
-			tagsSplit[i] = tagsSplit[i].replace(/</g, "&lt;").replace(/>/g, "&gt;");
-		    }
-		}
+
+        if (caption != null) {
+            caption = parseMarkdown(caption).filterTags(['img']).toHtml()
+        }
+
+        for (var i = 0; i < tagsSplit.length; i++) {
+            if (tagsSplit[i] != null) {
+                tagsSplit[i] = stripTag(tagsSplit[i])
+            }
+        }
+
 		Posts.create({type: type, title: title, content: contentSplit, caption: caption, tags: tagsSplit, references: referencesSplit}, function(err, imagePost) {
 		    if (err) return next(err);
 		    res.send(res.render('post/new', {postId: imagePost._id, host: hostURL}));


### PR DESCRIPTION
## Add Markdown support to Patsr 

This adds markdown support for patsr, using [this](https://www.npmjs.com/package/markdown) npm module for parsing. 

Specific changes: 

- add markdown/md.js, with method `parseMarkdown`. Usage like so:

```javascript
let text = `** text **, ![alt](link)`
let html = parseMarkdown(text).filterTags(['img']).toHtml()
```
This filters out all markdown image tags, though any other tags could be removed. In the above tag, the `![alt](link)` would be removed. Simply a convenience feature. These changes have been tested on my local machine, and appear to work fine. If merged, they should be more thoroughly tested.