### PR TITLE
Specify a `bin` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "start": "node ./bin/www"
   },
+  "bin": {
+    "patsr": "bin/www"
+  },
   "dependencies": {
     "body-parser": "~1.15.2",
     "config": "^1.25.1",


### PR DESCRIPTION
This allows PATSR to be installed with `npm install -g`.